### PR TITLE
Revise backend to enable more control over preamble

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,17 +50,41 @@ openpdf(report(
 `content` can always be either a single item or an array of items.
 
 * `latex = report(content)` assembles the LaTeX file
+* `latex = document(content)` gives more control over the look and feel of
+the document. See [here](#Advanced) for more.
 * `openpdf(latex)` compiles the LaTeX file and tries to open it
 * `Section(title, content)` creates a new section. A section is automatically translated to a Linux chapter, section or subsection according to its nesting
 * `Figure(caption, content)`
 * `Table(caption content)`
 * `Tabular(content)`
 * `Code(content)`
+* `TOC()` indicates a table of contents
+* `Abstract(content)` defines an abstract for the document
 * `Image(height, width, Array or Winston.FramePlot or Gadfly.Plot)`, where the array can be either of size `(m,n,1)` or RGB `(m,n,3)`, with the values in the range `0..1`
+
+## Advanced
+To define a custom document, use the `document` function, in combination with
+the following declarations, some of which can be omitted:
+
+* `DocumentClass("article", ["11pt", "letterpaper"])`
+declares the document class of the file. Settings are passed through a vector
+as the second parameter.
+* `Title("A LaTeX Library for Julia")` declares the title of the file.
+* `Date(1999, 12, 31)` declares the date of the file. Note that this is the
+same `Date` as in standard Julia.
+* `Author("John Smith")` declares the author of the file.
+
+For example, the following is a minimal document:
+
+    document([
+        DocumentClass("article", ["11pt", "letterpaper"]),
+        Date(2015, 11, 23),
+        Title("A LaTeX Library for Julia"),
+        Author("John Smith"),
+        Section("Code", [Code("""# minimal example""")])])
 
 ## Todos
 
-* make preable configurable
+* make preamble configurable
 * adapt `openpdf` to linux
 * add tests
-

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.4-
 SHA
 Images
-Iterators

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4-
 SHA
 Images
+Iterators

--- a/src/LaTeX.jl
+++ b/src/LaTeX.jl
@@ -3,7 +3,6 @@
 module LaTeX
 
 using SHA
-using Iterators
 import Images
 
 @windows_only include("wincall.jl")
@@ -323,7 +322,7 @@ function document(p, items)
 
     # build up the document starting from the beginning
     push!(preamble, processdecl(dclass))
-    for (package, settings) in chain(require, docrequire)
+    for (package, settings) in merge(require, docrequire)
         if isempty(settings)
             push!(preamble, "\\usepackage{$package}")
         else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,26 @@
 using LaTeX
+import LaTeX: getrequirements
 using Base.Test
 
-# write your own tests here
-@test 1 == 1
+# Check that package dependency is working
+@test haskey(
+    getrequirements(Section("Code", [Code("""test_getrequirements()""")])),
+    "texments")
+
+# Test a minimal document
+doc = document([
+    DocumentClass("article", ["11pt", "letterpaper"]),
+    Date(2015, 11, 23),
+    Title("Sample Article"),
+    Author("Andi Andromeda"),
+    Section("Code", [Code("""# minimal example""")])])
+@test split(doc, '\n')[1] == "\\documentclass[11pt,letterpaper]{article}"
+@test contains(doc, "\\date{2015-11-23}")
+@test contains(doc, "\\author{Andi Andromeda}")
+@test contains(doc, "\\section")  # articles have section as top-level
+@test contains(doc, "\\usestyle{default}")  # needed for code
+
+# Test a minimal report
+rep = report(Section("Test", "Lorum ipsum."))
+@test split(rep, '\n')[1] == "\\documentclass[11pt,a4paper]{report}"
+@test contains(rep, "\\chapter")  # reports have chapter as top-level


### PR DESCRIPTION
I added some more advanced package dependency analysis, so that graphicx and texments are only used when needed. I added the `document` function to allow more control over the document. In particular, articles are now supported, and LaTeX.jl will automatically use the correct section tags.

These changes have been documented and there is some test coverage added.
